### PR TITLE
 fix: update input and output types in MongoDb.node.ts to NodeConnectionType[]

### DIFF
--- a/nodes/MongoDb/GenericFunctions.ts
+++ b/nodes/MongoDb/GenericFunctions.ts
@@ -110,13 +110,11 @@ export function prepareItems(
 			}
 
 			if (fieldData) {
-				if (fieldData) {
-					if (dateFields.includes(field)) {
-						fieldData = new Date(fieldData as string);
-					}
-					if (oidFields.includes(field)) {
-						fieldData = new ObjectId(fieldData as string);
-					}
+				if (dateFields.includes(field)) {
+					fieldData = new Date(fieldData as string);
+				}
+				if (oidFields.includes(field)) {
+					fieldData = new ObjectId(fieldData as string);
 				}
 			}
 

--- a/nodes/MongoDb/MongoDb.node.ts
+++ b/nodes/MongoDb/MongoDb.node.ts
@@ -9,6 +9,7 @@ import type {
 	INodeTypeDescription,
 	JsonObject,
 } from 'n8n-workflow';
+import type { NodeConnectionType } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 
 import {EJSON} from 'bson';
@@ -46,8 +47,8 @@ export class MongoDb implements INodeType {
 		defaults: {
 			name: 'mongoDb',
 		},
-		inputs: ['main'],
-		outputs: ['main'],
+		inputs: <NodeConnectionType[]>['main'],
+		outputs: <NodeConnectionType[]>['main'],
 		credentials: [
 			{
 				name: 'mongoDb',

--- a/nodes/MongoDb/MongoDbProperties.ts
+++ b/nodes/MongoDb/MongoDbProperties.ts
@@ -257,6 +257,13 @@ export const nodeProperties: INodeProperties[] = [
 				default: false,
 				description: 'Whether to use dot notation to access date fields',
 			},
+			{
+				displayName: 'OID Fields',
+				name: 'oidFields',
+				type: 'string',
+				default: '',
+				description: 'Comma separeted list of fields that will be parse as Mongo OID type',
+			},
 		],
 	},
 ];


### PR DESCRIPTION
#2 
This pull request updates the input and output types in the MongoDb.node.ts file to NodeConnectionType[]. The change ensures that the inputs and outputs properties of the node are correctly typed, which resolves type errors related to improper assignment of connection types.